### PR TITLE
Separate mods and components

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -404,7 +404,9 @@ async function createReactAppWithChilliSourceFrontEndAt(templateDirectory, desti
 	execa.sync('npx', ['create-react-app', destinationDirectory]);
 
 	// Change context to the target location, if not already
-	ensureProcessIsRunningInTheCorrectDirectory(destinationDirectory);
+	if (!process.cwd().includes(destinationDirectory)) {
+		process.chdir(destinationDirectory);
+	}
 
 	// Install CS.Front.Core
 	console.log('');

--- a/helpers.js
+++ b/helpers.js
@@ -247,7 +247,7 @@ async function installModulesAndTheirDependencies(destinationDirectory, gitRepoL
 	// Only install if base CRA & ChilliFront App has been setup
 	if (fsExtra.existsSync('node_modules')) {
 		// Copy styles & modules
-		installUserSelectedModules(gitRepoLocation);
+		return installUserSelectedModules(gitRepoLocation);
 	} else {
 		console.log(
 			`The current directory does not look like a ${chalk.bold.red('create-react-app')} project.`

--- a/helpers.js
+++ b/helpers.js
@@ -16,7 +16,8 @@ const spinner = new Spinner('%s');
 spinner.setSpinnerString(`${chalk.yellow('|/-\\')}`);
 
 /**
- *
+ * Creates a directory at the specified path
+ * if it doesn't exist
  * @param {string} path The path at which to create a new directory
  */
 const generateDirectory = directoryPath => {
@@ -26,11 +27,14 @@ const generateDirectory = directoryPath => {
 };
 
 /**
- *
+ * Retrieves all directories and sub-directories
+ * starting at the path provided.
  * @param {string} rootPath
+ *
+ * @returns {string[]}
  */
-const getDirectories = rootPath =>
-	fsExtra
+const getDirectories = rootPath => {
+	return fsExtra
 		.readdirSync(rootPath)
 		.filter(directoryPath => {
 			if (fsExtra.statSync(path.join(rootPath, directoryPath)).isDirectory()) {
@@ -46,11 +50,16 @@ const getDirectories = rootPath =>
 
 			return false;
 		});
+};
 
 /**
- *
+ * Iterates over the provided directory and its sub-
+ * directories, goes through each `.packages` file
+ * and compiles a list of `.packages` files
  * @param {*} directory
  * @param {*} fileList
+ *
+ * @returns {string[]}
  */
 const getPackagesFileList = (directory, fileList) => {
 	if (directory[directory.length - 1] !== '/') {
@@ -77,17 +86,14 @@ const getPackagesFileList = (directory, fileList) => {
  * @param {string} destinationDirectory The target directory where to install the modules
  * @param {string} gitRepoLocation The path to where to copy contents from
  *
- * @returns {Promise} A promise
+ * @returns {Promise}
  */
 const installStyleHelpers = (destinationDirectory, gitRepoLocation) => {
 	console.log('');
 	console.log(`Installing ${chalk.bold.greenBright('Styling Helpers')}`);
 
-	// Ensure the process is running in the correct directory
-	const formattedDestinationDirectory = destinationDirectory.slice(2);
-	if (!process.cwd().includes(formattedDestinationDirectory)) {
-		process.chdir(formattedDestinationDirectory);
-	}
+	// Change context to the target location, if not already
+	ensureProcessIsRunningInTheCorrectDirectory(destinationDirectory);
 
 	// Only install if base CRA & ChilliFront App has been setup
 	if (fsExtra.existsSync('node_modules')) {
@@ -140,7 +146,8 @@ async function temporarilyCloneGitRepo(repositoryUrl, gitRepoLocation) {
 }
 
 /**
- *
+ * Installs the `Mod`s selected by the user into
+ * the target directory
  * @param {string} gitRepoLocation The path to where to copy contents from
  */
 async function installUserSelectedModules(gitRepoLocation) {
@@ -196,7 +203,7 @@ async function installUserSelectedModules(gitRepoLocation) {
 		const installStatus = await execa('yarn', dependencyList);
 		console.log(`--- ${installStatus.stdout}`);
 		console.log('');
-		console.log(`${chalk.cyan(`npx ${name} --modules`)}`);
+		console.log(`${chalk.cyan(`npx ${name} --only-modules`)}`);
 		console.log('');
 		console.log('Happy coding!');
 		console.log('|‾‾‾‾‾‾‾‾‾‾‾‾|');
@@ -214,7 +221,7 @@ async function installUserSelectedModules(gitRepoLocation) {
 			)} installed any modules at this time. You can do so later by running the following command:`
 		);
 		console.log('');
-		console.log(`${chalk.cyan(`npx ${name} --modules`)}`);
+		console.log(`${chalk.cyan(`npx ${name} --only-modules`)}`);
 		console.log('');
 		console.log('Happy coding!');
 		console.log('|‾‾‾‾‾‾‾‾‾‾‾‾|');
@@ -234,11 +241,8 @@ async function installUserSelectedModules(gitRepoLocation) {
  * @param {string} gitRepoLocation The location on the local machine where to install
  */
 async function installModulesAndTheirDependencies(destinationDirectory, gitRepoLocation) {
-	// Ensure the process is running in the correct directory
-	const formattedDestinationDirectory = destinationDirectory.slice(2);
-	if (!process.cwd().includes(formattedDestinationDirectory)) {
-		process.chdir(formattedDestinationDirectory);
-	}
+	// Change context to the target location, if not already
+	ensureProcessIsRunningInTheCorrectDirectory(destinationDirectory);
 
 	// Only install if base CRA & ChilliFront App has been setup
 	if (fsExtra.existsSync('node_modules')) {
@@ -252,6 +256,117 @@ async function installModulesAndTheirDependencies(destinationDirectory, gitRepoL
 		console.log();
 		console.log(`${chalk.cyan(`npx ${name} <project-directory>`)}`);
 		process.exit(1);
+	}
+}
+
+/**
+ * Shows the user a prompt with all available modules and then installs the modules
+ * which the user has selected.
+ * @param {string} destinationDirectory The target directory where to install the modules
+ * @param {string} gitRepoLocation The location on the local machine where to install
+ */
+async function installComponentsAndTheirDependencies(destinationDirectory, gitRepoLocation) {
+	// Change context to the target location, if not already
+	ensureProcessIsRunningInTheCorrectDirectory(destinationDirectory);
+
+	// Only install if ChilliFront App has been setup
+	if (fsExtra.existsSync('node_modules')) {
+		// Copy styles & modules
+		installUserSelectedComponents(gitRepoLocation);
+	} else {
+		console.log(
+			`The current directory does not look like a ${chalk.bold.red('create-react-app')} project.`
+		);
+		console.log('You can start over by deleting this directory and running the following command:');
+		console.log();
+		console.log(`${chalk.cyan(`npx ${name} <project-directory>`)}`);
+		process.exit(1);
+	}
+}
+
+/**
+ * Installs the components selected by the user into
+ * the target directory
+ * @param {string} gitRepoLocation The path to where to copy contents from
+ */
+async function installUserSelectedComponents(gitRepoLocation) {
+	// Make a directory for modules
+	generateDirectory('./src/components');
+	console.log('');
+	// Deal with CS.Front.Modules
+	console.log(`${chalk.yellow('Select your components. Fetching the latest list...')}`);
+	const chilliSourceFrontComponentList = await getDirectories(gitRepoLocation + '/components');
+
+	console.log('');
+	const userSelection = await inquirer.prompt([
+		{
+			message: 'Select modules to import',
+			type: 'checkbox',
+			choices: chilliSourceFrontComponentList,
+			name: 'userSelectedComponents',
+		},
+	]);
+
+	// Get user selected modules
+	const components = userSelection['userSelectedComponents'];
+
+	if (components.length > 0) {
+		console.log('');
+		console.log(`You've ${chalk.green('selected')} the following components:`);
+		components.forEach(component => {
+			console.log(`--- ${chalk.cyan(component)}`);
+		});
+
+		// Install each component selected by user
+		console.log('');
+		console.log(`Installing components:`);
+		components.forEach(component => {
+			fsExtra.copySync(
+				path.join(gitRepoLocation, 'components', component),
+				path.join('./src/components', component)
+			);
+
+			console.log(`--- ${chalk.bold.cyan(component)} : Done`);
+		});
+
+		// Install dependencies
+		console.log('');
+		console.log(`Installing dependencies for selected components...`);
+		console.log('');
+		const dependencyList = getDependenciesForPackages('./src/components');
+
+		dependencyList.unshift('add');
+		const installStatus = await execa('yarn', dependencyList);
+		console.log(`--- ${installStatus.stdout}`);
+		console.log('');
+		console.log(`${chalk.cyan(`npx ${name} --only-components`)}`);
+		console.log('');
+		console.log('Happy coding!');
+		console.log('|‾‾‾‾‾‾‾‾‾‾‾‾|');
+		console.log('| BLUECHILLI |');
+		console.log('|____________|');
+		console.log('(__/) || ');
+		console.log('(•ㅅ•) || ');
+		console.log('/ 　 づ');
+		console.log('');
+	} else {
+		console.log('');
+		console.log(
+			`You ${chalk.bold.red(
+				"haven't"
+			)} installed any components at this time. You can do so later by running the following command:`
+		);
+		console.log('');
+		console.log(`${chalk.cyan(`npx ${name} --only-components`)}`);
+		console.log('');
+		console.log('Happy coding!');
+		console.log('|‾‾‾‾‾‾‾‾‾‾‾‾|');
+		console.log('| BLUECHILLI |');
+		console.log('|____________|');
+		console.log('(__/) || ');
+		console.log('(•ㅅ•) || ');
+		console.log('/ 　 づ');
+		console.log('');
 	}
 }
 
@@ -289,9 +404,7 @@ async function createReactAppWithChilliSourceFrontEndAt(templateDirectory, desti
 	execa.sync('npx', ['create-react-app', destinationDirectory]);
 
 	// Change context to the target location, if not already
-	if (!process.cwd().includes(destinationDirectory)) {
-		process.chdir(destinationDirectory);
-	}
+	ensureProcessIsRunningInTheCorrectDirectory(destinationDirectory);
 
 	// Install CS.Front.Core
 	console.log('');
@@ -330,10 +443,23 @@ async function createReactAppWithChilliSourceFrontEndAt(templateDirectory, desti
 	console.log(`--- ${installNodeSass.stdout}`);
 }
 
+/**
+ * Ensures the process always runs in the correct directory
+ * @param {string} destinationDirectory The target directory where to install the modules
+ */
+const ensureProcessIsRunningInTheCorrectDirectory = destinationDirectory => {
+	// Ensure the process is running in the correct directory
+	const formattedDestinationDirectory = destinationDirectory.slice(2);
+	if (!process.cwd().includes(formattedDestinationDirectory)) {
+		process.chdir(formattedDestinationDirectory);
+	}
+};
+
 module.exports = {
 	createReactAppWithChilliSourceFrontEndAt,
 	installModulesAndTheirDependencies,
 	generateDirectory,
 	installStyleHelpers,
 	temporarilyCloneGitRepo,
+	installComponentsAndTheirDependencies,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -300,7 +300,7 @@ async function installUserSelectedComponents(gitRepoLocation) {
 	console.log('');
 	const userSelection = await inquirer.prompt([
 		{
-			message: 'Select modules to import',
+			message: 'Select components to import',
 			type: 'checkbox',
 			choices: chilliSourceFrontComponentList,
 			name: 'userSelectedComponents',

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ if (program.onlyStyles) {
 }
 
 /** If no flag, then create a starter app */
-if (!program.onlyModules && !program.onlyStyles) {
+if (!program.onlyModules && !program.onlyStyles && !program.onlyComponents) {
 	// Inform the user
 	console.log('');
 	console.log(
@@ -99,5 +99,6 @@ if (!program.onlyModules && !program.onlyStyles) {
 	)
 		.then(cloneRepo)
 		.then(installStyles)
-		.then(installModules);
+		.then(installModules)
+		.then(installComponents);
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const {
 	generateDirectory,
 	installStyleHelpers,
 	temporarilyCloneGitRepo,
+	installComponentsAndTheirDependencies,
 } = require('./helpers');
 
 /** Variables */
@@ -29,6 +30,7 @@ const program = new commander.Command(packageJson.name)
 	.usage(`${chalk.green('<project-directory>')}`)
 	.option('-m, --only-modules', 'Install modules only')
 	.option('-s, --only-styles', 'Install style-helpers only')
+	.option('-c, --only-components', 'Install components only')
 	.action(projectDirectory => {
 		targetDirectory = projectDirectory;
 	})
@@ -61,11 +63,19 @@ const installModules = () =>
 
 const installStyles = () => installStyleHelpers(targetDirectory, tempLocationOfGitRepoModules);
 
+const installComponents = () =>
+	installComponentsAndTheirDependencies(targetDirectory, tempLocationOfGitRepoModules);
+
 const cloneRepo = () => temporarilyCloneGitRepo(CSFrontModulesUrl, tempLocationOfGitRepoModules);
 
 /** If modules flag provided, install modules */
 if (program.onlyModules) {
 	cloneRepo().then(installModules);
+}
+
+/** If components flag provided, install components */
+if (program.onlyComponents) {
+	cloneRepo().then(installComponents);
 }
 
 /** If styles flag provided, install styles */


### PR DESCRIPTION
This PR adds one more option to the project creation - components!

Now we have the following commands available to devs

- [ ] Create a new project from scratch
```shell
npx bc-starter-template <TARGET_DIRECTORY>
```

- [ ] Install only modules
```shell
npx bc-starter-template <TARGET_DIRECTORY> -m
```
```shell
npx bc-starter-template <TARGET_DIRECTORY> --only-modules
```

- [ ] Install only styles
```shell
npx bc-starter-template <TARGET_DIRECTORY> -s
```
```shell
npx bc-starter-template <TARGET_DIRECTORY> --only-styles
```

- [ ] Install only components
```shell
npx bc-starter-template <TARGET_DIRECTORY> -c
```
```shell
npx bc-starter-template <TARGET_DIRECTORY> --only-components
```